### PR TITLE
[Sentry-202345] Route access token traffic to primary db

### DIFF
--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -208,7 +208,8 @@ class TokenView(OAuthLibMixin, View):
             access_token = json.loads(body).get("access_token")
             if access_token is not None:
                 token = get_access_token_model().objects.get(
-                    token=access_token)
+                    token=access_token
+                ).using("default")
                 app_authorized.send(
                     sender=self, request=request,
                     token=token)


### PR DESCRIPTION
[Sentry](https://sentry.drchrono.com/drchrono/drchrono-web/issues/202345/events/latest/)

This is introduced in the version upgrade, https://github.com/drchrono/django-oauth-toolkit/compare/django-19...drchrono:django_1_11 #diff-c364c574f9e0ee3ae3b4e9230752e9cdL173 (ahhh... they cannot parse the anchor link when compare)
From django-oauth-toolkit verison 1.1.0, there will be a signal sent out whenever an app is authorized, and this signal requires a query for access token.

As the replication lag is the cause for the issue, I am going to route this request to primary DB.
And in terms of traffic, we don't throttle token exchange requests at the moment, but as the request is not complicated, it shouldn't cause much effect.