### PR TITLE
Set error header when no token provided

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -358,6 +358,7 @@ class OAuth2Validator(RequestValidator):
         """
         if not token:
             self._set_oauth2_error_on_request(request, None, scopes)
+            # This is a temporary logging 
             log.exception("Authorization failed. No valid token provided.")
             return False
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -358,8 +358,11 @@ class OAuth2Validator(RequestValidator):
         """
         if not token:
             self._set_oauth2_error_on_request(request, None, scopes)
-            # This is a temporary logging 
-            log.exception("Authorization failed. No valid token provided.")
+            # This is a temporary logging
+            # As the auth header will be filtered out in sentry
+            # add a sample token to exception
+            _token = request.headers.get("Authorization", "")[:10]
+            log.exception("Authorization failed. No token provided. Auth: [{}]".format(_token))
             return False
 
         introspection_url = oauth2_settings.RESOURCE_SERVER_INTROSPECTION_URL

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -357,6 +357,8 @@ class OAuth2Validator(RequestValidator):
         When users try to access resources, check that provided token is valid
         """
         if not token:
+            self._set_oauth2_error_on_request(request, None, scopes)
+            log.exception("Authorization failed. No valid token provided.")
             return False
 
         introspection_url = oauth2_settings.RESOURCE_SERVER_INTROSPECTION_URL


### PR DESCRIPTION
When there's no token provided in the request, the `WWW-Authenticate` response header that is used to indicate authorization status, is not set.
Also, add a temporary logging to verify.